### PR TITLE
Renamed kid_value to public_key_id with backwards compat

### DIFF
--- a/src/BoxAPIServiceProviderLumen.php
+++ b/src/BoxAPIServiceProviderLumen.php
@@ -25,10 +25,10 @@ class BoxAPIServiceProviderLumen extends ServiceProvider
             'enterprise_id'     => $_ENV['BOX_ENTERPRISE_ID'],
             'app_user_name'     => $_ENV['BOX_APP_USER_NAME'],
             'app_user_id'       => $_ENV['BOX_APP_USER_ID'],
-            'kid_value'         => $_ENV['BOX_KID_VALUE'],
+            'public_key_id'     => $_ENV['BOX_PUBLIC_KEY_ID'],
             'passphrase'        => $_ENV['BOX_PASSPHRASE'],
             'expiration'        => $_ENV['BOX_EXPIRATION'],
-            'private_key_file'  => base_path() . "/" . $_ENV['BOX_PRIVATE_KEY_FILE']        
+            'private_key_file'  => base_path() . "/" . $_ENV['BOX_PRIVATE_KEY_FILE']
         );
 
         // create image

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -4,10 +4,10 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Box Developer IDs 
+    | Box Developer IDs
     |--------------------------------------------------------------------------
     |
-    | Set these value based on this documentation 
+    | Set these value based on this documentation
     | https://box-content.readme.io/docs/box-platform
     |
     */
@@ -20,7 +20,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Get Enterprise IDs 
+    | Get Enterprise IDs
     |--------------------------------------------------------------------------
     |
     | Login into box.com and go to admin console menu on top left.
@@ -33,11 +33,11 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Set Username or User Id 
+    | Set Username or User Id
     |--------------------------------------------------------------------------
     |
     | Set user name to use as App User in Enterprise. Usually need single user.
-    | Set user id if you know exactly the user id of Enterprise user 
+    | Set user id if you know exactly the user id of Enterprise user
     | to use this API.
     |
     */
@@ -53,7 +53,7 @@ return [
     | Set expiration time in second after request token. Max 60 seconds.
     |
     */
-   
+
     'expiration'    	=> 60,
 
     /*
@@ -67,7 +67,7 @@ return [
     |
     */
 
-    'kid_value'         => '',
+    'public_key_id'     => '',
     'private_key_file'  => 'private_key.pem',
     'passphrase'        => '1234',
 

--- a/tests/BoxAUContentTest.php
+++ b/tests/BoxAUContentTest.php
@@ -20,10 +20,10 @@ class BoxAUContentTest extends PHPUnit_Framework_TestCase
 	        'enterprise_id'		=> '',
 	        'app_user_name'		=> '',
 	        'app_user_id'		=> '',
-	        'kid_value'			=> '',
+	        'public_key_id'		=> '',
 	        'passphrase'		=> '',
 	        'expiration'		=> 60,
-	        'private_key_file'	=> 'private_key.pem',    		
+	        'private_key_file'	=> 'private_key.pem',
     	);
     	$this->client = new BoxAppUser($config);
     }


### PR DESCRIPTION
Renamed kid_value config param to public_key_id. This helps make the parameter self documenting.

I also added backwards compatibility, you may or may not want to remove this.

See #11 