### PR TITLE
Made private methods/properties protected to allow for easier extensi…

### DIFF
--- a/src/BoxContent.php
+++ b/src/BoxContent.php
@@ -84,8 +84,8 @@ trait BoxContent {
 	/* Restore a folder */
 	public function restoreFolder($folder_id, $newname = '', $json = false) {
 		$url = $this->api_url . "/folders/$folder_id";
-		if (empty($newname)) { 
-			$data = "-d '{\"name\": \"$newname\"}'"; 
+		if (empty($newname)) {
+			$data = "-d '{\"name\": \"$newname\"}'";
 		}
 		return $this->post($url, $json, $data);
 	}
@@ -95,9 +95,9 @@ trait BoxContent {
 	|
 	| ================================= File API Methods ==================================
 	| Check Box documentation here https://box-content.readme.io/reference#files
-	|  
+	|
 	*/
-	
+
 	/* Get the details of the mentioned file */
 	public function getFileInfo($file_id, $json = false) {
 		$url = $this->api_url . "/files/$file_id";
@@ -204,7 +204,7 @@ trait BoxContent {
 	/* Get embed link of a file */
 	public function getEmbedLink($file_id, $json = false) {
 		$url = $this->api_url . "/files/$file_id?fields=expiring_embed_link";
-		return $this->get($url, $json);		
+		return $this->get($url, $json);
 	}
 
 	/* Share a file */
@@ -229,8 +229,8 @@ trait BoxContent {
 	/* Restore a file */
 	public function restoreItem($file_id, $newname = '', $json = false) {
 		$url = $this->api_url . "/files/$file_id";
-		if (empty($newname)) { 
-			$data = "-d '{\"name\": \"$newname\"}'"; 
+		if (empty($newname)) {
+			$data = "-d '{\"name\": \"$newname\"}'";
 		}
 		return $this->post($url, $json, $data);
 	}
@@ -249,7 +249,7 @@ trait BoxContent {
 
 	// ================================= Helper Methods ==================================
 
-	private function get($url, $json = false, $data = '') {
+	protected function get($url, $json = false, $data = '') {
 		$data = shell_exec("curl $url $this->auth_header $data");
 		if ($json) {
 			return $data;
@@ -258,27 +258,27 @@ trait BoxContent {
 		}
 	}
 
-	private function post($url, $json = false, $data = '') {
+	protected function post($url, $json = false, $data = '') {
 		$data = shell_exec("curl $url $this->auth_header $data -X POST");
 		if ($json) {
 			return $data;
 		} else {
 			return json_decode($data, true);
 		}
-	} 
+	}
 
-	private function put($url, $json = false, $data = '') {
+	protected function put($url, $json = false, $data = '') {
 		$data = shell_exec("curl $url $this->auth_header $data -X PUT");
 		if ($json) {
 			return $data;
 		} else {
 			return json_decode($data, true);
 		}
-	} 
+	}
 
-	private function delete($url) {
+	protected function delete($url) {
 		$data = shell_exec("curl $url $this->auth_header -X DELETE");
 		return $data;
-	} 
+	}
 
 }

--- a/src/BoxStandardUser.php
+++ b/src/BoxStandardUser.php
@@ -17,18 +17,18 @@ class BoxStandardUser {
         'redirect_uri'		=> '',
     );
 
-	private $refresh_token	= '';
-	private $access_token	= '';
-	private $auth_header	= '';
+	protected $refresh_token	= '';
+	protected $access_token	= '';
+	protected $auth_header	= '';
 
 	// These urls below used for Box Content API
-	private $token_url	 	= 'https://api.box.com/oauth2/token';
-	private $api_url 		= 'https://api.box.com/2.0';
-	private $upload_url 	= 'https://upload.box.com/api/2.0';
-	private $authorize_url 	= 'https://app.box.com/api/oauth2/authorize';
+	protected $token_url	 	= 'https://api.box.com/oauth2/token';
+	protected $api_url 		= 'https://api.box.com/2.0';
+	protected $upload_url 	= 'https://upload.box.com/api/2.0';
+	protected $authorize_url 	= 'https://app.box.com/api/oauth2/authorize';
 
 	// This url below used for get App User access_token in JWT
-	private $audience_url 	= 'https://api.box.com/oauth2/token';
+	protected $audience_url 	= 'https://api.box.com/oauth2/token';
 
 	public function __construct(array $config = array())
 	{
@@ -48,19 +48,19 @@ class BoxStandardUser {
 		$this->auth_header 	= "-H \"Authorization: Bearer $this->access_token\"";
 
 	}
-	
+
 	/**
     * Overrides configuration settings
     *
     * @param array $config
     */
-	private function configure(array $config = array())
+	protected function configure(array $config = array())
     {
         $this->config = array_replace($this->config, $config);
         return $this;
     }
 
-	private function getCode() {
+	protected function getCode() {
 
 		$url = $this->authorize_url.'?'.http_build_query(array(
 			'response_type'	=> 'code',
@@ -78,15 +78,15 @@ class BoxStandardUser {
 		$url = $this->token_url;
 		if(!empty($this->refresh_token)){
 			$querystring = http_build_query(array(
-				'grant_type' 	=> 'refresh_token', 
-				'refresh_token' => $this->refresh_token, 
-				'client_id' 	=> $this->config['su_client_id'], 
+				'grant_type' 	=> 'refresh_token',
+				'refresh_token' => $this->refresh_token,
+				'client_id' 	=> $this->config['su_client_id'],
 				'client_secret' => $this->config['su_client_secret']));
 		} else {
 			$querystring = http_build_query(array(
-				'grant_type' 	=> 'authorization_code', 
-				'code' 			=> $code, 
-				'client_id' 	=> $this->config['su_client_id'], 
+				'grant_type' 	=> 'authorization_code',
+				'code' 			=> $code,
+				'client_id' 	=> $this->config['su_client_id'],
 				'client_secret' => $this->config['su_client_secret']));
 		}
 
@@ -131,7 +131,7 @@ class BoxStandardUser {
 			return true;
 		}
 	}
-	
+
 	/* Loads the token */
 	public function loadToken() {
 		$array = $this->readToken('file');
@@ -158,7 +158,7 @@ class BoxStandardUser {
 		}
 	}
 
-	private function expired($expires_in, $timestamp) {
+	protected function expired($expires_in, $timestamp) {
 		$ctimestamp = time();
 		if(($ctimestamp - $timestamp) >= $expires_in){
 			return true;


### PR DESCRIPTION
…on of classes

At present the private methods and properties make extending certain classes very difficult.

For example if I wanted to extend BoxAppUser and add a new api search method, I cannot call $this->get() in my new search method, because it is private within BoxContent, instead of protected. The same applies if I want to override one of the private methods in BoxAppUser, in order to make a minor alteration.

This pull request fixes this issue and goes another step in making the package more extensible.